### PR TITLE
Fixes for Octave 5.2.0 / Bugfix in usage of dim_vector

### DIFF
--- a/h5read.cc
+++ b/h5read.cc
@@ -75,7 +75,7 @@ check_vec (const octave_value& val, Matrix& mat/*out*/,
   if (error_state)
     return 0;
 
-  if (! mat.is_vector ())
+  if (! mat.isvector ())
     {
       error ("%s must be a vector", name);
       return 0;
@@ -754,8 +754,8 @@ H5File::read_dset_hyperslab (const char *dsetname,
   if (open_dset (dsetname) < 0)
     return octave_value ();
 
-  if (rank == 0 && ! (start.is_empty () && count.is_empty ()
-                      && stride.is_empty () && block.is_empty ()))
+  if (rank == 0 && ! (start.isempty () && count.isempty ()
+                      && stride.isempty () && block.isempty ()))
     {
       error ("Cannot specify hyperslab for scalar datasets (rank 0)");
       return octave_value ();
@@ -1018,7 +1018,7 @@ H5File::write_dset (const char *dsetname,
 
   herr_t status;
   // find the right type
-  if (ov_data.is_complex_type())
+  if (ov_data.iscomplex())
     {
       //check if the data set already exists. if it does, open it,
       //otherwise, create it.  Furthermore check if the datatype is
@@ -1044,7 +1044,7 @@ H5File::write_dset (const char *dsetname,
       ComplexNDArray data = ov_data.complex_array_value ();
       OPEN_AND_WRITE;
     }
-  else if (ov_data.is_integer_type ())
+  else if (ov_data.isinteger ())
     {
       if (ov_data.is_uint64_type ())
         {
@@ -1136,8 +1136,8 @@ H5File::write_dset_hyperslab (const char *dsetname,
     return;
 
   // check if the given hyperslab settings are reasonable
-  if (rank == 0 && ! (start.is_empty () && count.is_empty ()
-                      && stride.is_empty () && block.is_empty ()))
+  if (rank == 0 && ! (start.isempty () && count.isempty ()
+                      && stride.isempty () && block.isempty ()))
     {
       error ("Cannot specify hyperslab for scalar datasets (rank 0)");
       return;
@@ -1462,7 +1462,7 @@ H5File::write_att (const char *location, const char *attname,
       
       buf = (void *) attvalue.string_value ().c_str ();
     }
-  else if (attvalue.is_integer_type ())
+  else if (attvalue.isinteger ())
     {
       //type_id = H5Tcopy (H5T_STD_I64LE); //cannot read this back in then, don't know why
       type_id = H5Tcopy (H5T_NATIVE_INT);
@@ -1470,14 +1470,14 @@ H5File::write_att (const char *location, const char *attname,
       attval_int = attvalue.int_value ();
       buf = (void *) &attval_int;
     }
-  else if (attvalue.is_real_type ())
+  else if (attvalue.isreal ())
     {
       type_id = H5Tcopy (H5T_NATIVE_DOUBLE);
       mem_type_id = H5Tcopy (H5T_NATIVE_DOUBLE);
       attval_double = attvalue.double_value ();
       buf = (void *) &attval_double;
     }
-  else if (attvalue.is_complex_type ())
+  else if (attvalue.iscomplex ())
     {
       error ("complex values are not supported by the HDF5 format. \
 You have to save real and imag part separately.");
@@ -1574,14 +1574,14 @@ H5File::create_dset (const char *location, const Matrix& size,
   free (dims);
   free (maxdims);
 
-  if (any_int_leq_zero (size) && chunksize.is_empty())
+  if (any_int_leq_zero (size) && chunksize.isempty())
     {
       error ("If the size argument contains an Inf or zero element, then ChunkSize must be specified.");
       return;
     }
   // get a dataset creation property list
   hid_t crp_list = H5Pcreate (H5P_DATASET_CREATE);
-  if (! chunksize.is_empty())
+  if (! chunksize.isempty())
     {
       // a dataset with an unlimited dimension must be chunked.
       if (chunksize(0) == 0)

--- a/h5read.cc
+++ b/h5read.cc
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <algorithm>
 #include <string>
-#include "gripes.h"
 #include "file-stat.h"
 
 using namespace std;
@@ -599,7 +598,7 @@ H5File::H5File (const char *filename, const bool create_if_nonexisting,
   //suppress hdf5 error output
   H5Eset_auto (H5E_DEFAULT,0,0);
 
-  file_stat fs (filename);
+  octave::sys::file_stat fs (filename);
   if (! fs.exists () && create_if_nonexisting)
     file = H5Fcreate (filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   else if (! fs.exists () && ! create_if_nonexisting)

--- a/h5read.h
+++ b/h5read.h
@@ -92,7 +92,8 @@ class H5File
   octave_value read_dset ();
   Matrix get_auto_chunksize (const Matrix& size, int typesize);
 
-  template <typename T> hsize_t* alloc_hsize (const T& dim, const int mode, const bool reverse);
+  hsize_t* alloc_hsize (const Matrix& dim, const int mode, const bool reverse);
+  hsize_t* alloc_hsize (const dim_vector& dim, const int mode, const bool reverse);
 
 };
 


### PR DESCRIPTION
Hello,
I made some small fixes to compile the package on Fedora 33 with GCC 10.2.1 and GNU Octave 5.2.0 and replaced some function calls that were deprecated in GNU Octave 4.4.
Furthermore, I found an error in the usage of the Octave dim_vector class which caused a lot of tests to fail. For me, all tests now pass.
Please have a look at the changes yourself.
Best regards,
Lukas